### PR TITLE
Decrease permutation count for fit-symmetry parsing with symmetry groups with more than 2 elements

### DIFF
--- a/pyRMSD/RMSDCalculator.py
+++ b/pyRMSD/RMSDCalculator.py
@@ -208,7 +208,7 @@ class RMSDCalculator(object):
             symm_rmsds = []
             original = [numpy.array(i).flatten() for i in self.fit_symmetry_groups]
             for permutation in symm_permutations_new(self.fit_symmetry_groups):
-                
+                # Copy the coordinates and convert to matrix form for ease of indexing
                 coords_copy = numpy.array(np_coords_fit, copy= True, dtype = numpy.float64)
                 coords_copy.shape = (self.number_of_conformations, self.number_of_fitting_atoms,3)
                 ind = 0

--- a/pyRMSD/RMSDCalculator.py
+++ b/pyRMSD/RMSDCalculator.py
@@ -206,19 +206,19 @@ class RMSDCalculator(object):
             # If we have fitting symmetry groups, we have to try with all possible combinations.
             # Calculation symmetry groups are applied at C level, changing the way RMSD is calculated.
             symm_rmsds = []
-            for permutation in symm_permutations(self.fit_symmetry_groups):
+            for permutation in symm_permutations_new(self.fit_symmetry_groups):
                 
                 # Copy the coordinates and convert to matrix form for ease of indexing
                 coords_copy = numpy.array(np_coords_fit, copy= True, dtype = numpy.float64)
                 coords_copy.shape = (self.number_of_conformations, self.number_of_fitting_atoms,3)
-                
+                original = [numpy.hstack(numpy.array(i).T) for i in self.fit_symmetry_groups]
                 # Apply the changes to reference
+                ind = 0
                 for symm_group in permutation:
                     # Do it only if the symm. group is not permuted. Otherwise we would always permute!
-                    if not symm_group in self.fit_symmetry_groups:
-                        for symm_pair in symm_group:
-                            swap_atoms(coords_copy[conformation_number], symm_pair[0], symm_pair[1])
-                    
+                    new_indexes = np.hstack(symm_group.T) 
+                    coords_copy[conformation_number][original[ind], :] = coords_copy[conformation_number][new_indexes, :]
+                    ind += 1
                 # Flatten again to feed the C calculator
                 coords_copy.shape = (self.number_of_conformations*self.number_of_fitting_atoms*3)
                 

--- a/pyRMSD/RMSDCalculator.py
+++ b/pyRMSD/RMSDCalculator.py
@@ -3,7 +3,7 @@ import numpy
 import pyRMSD.calculators
 from pyRMSD.availableCalculators import availableCalculators
 from pyRMSD.symmTools import symm_permutations, swap_atoms, min_rmsd_of_rmsds_list,\
-    symm_groups_validation
+    symm_groups_validation, symm_permutations_new, symm_groups_validation_new
 
 class RMSDCalculator(object):
     """
@@ -71,7 +71,7 @@ class RMSDCalculator(object):
             self.__number_of_threads = 8
 
             # Symmetry group handling
-            symm_groups_validation(fitSymmetryGroups)
+            symm_groups_validation_new(fitSymmetryGroups)
             symm_groups_validation(calcSymmetryGroups)
             self.fit_symmetry_groups = fitSymmetryGroups
             self.calc_symmetry_groups = calcSymmetryGroups
@@ -206,23 +206,18 @@ class RMSDCalculator(object):
             # If we have fitting symmetry groups, we have to try with all possible combinations.
             # Calculation symmetry groups are applied at C level, changing the way RMSD is calculated.
             symm_rmsds = []
+            original = [numpy.array(i).flatten() for i in self.fit_symmetry_groups]
             for permutation in symm_permutations_new(self.fit_symmetry_groups):
                 
-                # Copy the coordinates and convert to matrix form for ease of indexing
                 coords_copy = numpy.array(np_coords_fit, copy= True, dtype = numpy.float64)
                 coords_copy.shape = (self.number_of_conformations, self.number_of_fitting_atoms,3)
-                original = [numpy.hstack(numpy.array(i).T) for i in self.fit_symmetry_groups]
-                # Apply the changes to reference
                 ind = 0
                 for symm_group in permutation:
-                    # Do it only if the symm. group is not permuted. Otherwise we would always permute!
-                    new_indexes = np.hstack(symm_group.T) 
+                    new_indexes = numpy.array(symm_group).flatten()
                     coords_copy[conformation_number][original[ind], :] = coords_copy[conformation_number][new_indexes, :]
                     ind += 1
-                # Flatten again to feed the C calculator
                 coords_copy.shape = (self.number_of_conformations*self.number_of_fitting_atoms*3)
                 
-                # And calculate the RMSD of this permutation
                 symm_rmsds.append(pyRMSD.calculators.oneVsFollowing(availableCalculators()[self.calculator_type],
                                                          coords_copy,
                                                          self.number_of_fitting_atoms,

--- a/pyRMSD/symmTools.py
+++ b/pyRMSD/symmTools.py
@@ -18,6 +18,22 @@ def symm_groups_validation( symm_groups):
                     raise Exception
     except Exception:
         raise ValueError('Symmetry groups are not well defined')
+        
+        
+def symm_groups_validation_new( symm_groups):
+    """
+    Checks that symmetry groups are well defined (each n-tuple has a correspondent symmetric n-tuple)
+    """
+    try:
+        for sg in symm_groups:
+            current_length = None
+            for symm_pair in sg:
+                if current_length is None:
+                    current_length = len(symm_pair)
+                if len(symm_pair) != current_length:
+                    raise Exception
+    except Exception:
+        raise ValueError('Symmetry groups are not well defined')
 
 
 

--- a/pyRMSD/symmTools.py
+++ b/pyRMSD/symmTools.py
@@ -22,18 +22,16 @@ def symm_groups_validation( symm_groups):
         
 def symm_groups_validation_new( symm_groups):
     """
-    Checks that symmetry groups are well defined (each n-tuple has a correspondent symmetric n-tuple)
+    Checks that symmetry groups are well defined (each n-tuple has a correspondent symmetric n-tuple).
+    Allows Multi-Unit symmgroups, i.e. with > 2 elements
     """
-    try:
-        for sg in symm_groups:
-            current_length = None
-            for symm_pair in sg:
-                if current_length is None:
-                    current_length = len(symm_pair)
-                if len(symm_pair) != current_length:
-                    raise Exception
-    except Exception:
-        raise ValueError('Symmetry groups are not well defined')
+    for sg in symm_groups:
+        current_length = None
+        for symm_pair in sg:
+            if current_length is None:
+                current_length = len(symm_pair)
+            if len(symm_pair) != current_length:
+                raise ValueError('Symmetry groups are not well defined')
 
 
 
@@ -80,7 +78,7 @@ def symm_permutations_new(groups):
             [ [1,2,0] ], 
             [ [3,4],[5,6] ]
         ]
-    Meaning that coordinates 1 and 2 and 3 are equivalent, and that 3 and 4, as well as 5 and 6 are equivalen and must be changed 
+    Meaning that coordinates 0 and 1 and 2 are equivalent, and that 3 and 4, as well as 5 and 6 are equivalent and must be changed 
     at the same time (they form a group). 
     The possible permutations are:
         [(1,2,0)] [(3,4) (5,6)]

--- a/pyRMSD/symmTools.py
+++ b/pyRMSD/symmTools.py
@@ -4,6 +4,7 @@ Created on 29/07/2013
 @author: victor
 """
 from __future__ import print_function
+from itertools import permutations
 
 
 def symm_groups_validation( symm_groups):
@@ -54,6 +55,46 @@ def symm_permutations(groups):
             yield [swapped_head] + tail_permutation
     else:
         yield []
+
+def symm_permutations_new(groups):
+    """
+    Generator that produces the possible permutations of the symmetry groups.
+    Suposing we have this symmetries definition:
+        [
+            [ [1,2,0] ], 
+            [ [3,4],[5,6] ]
+        ]
+    Meaning that coordinates 1 and 2 and 3 are equivalent, and that 3 and 4, as well as 5 and 6 are equivalen and must be changed 
+    at the same time (they form a group). 
+    The possible permutations are:
+        [(1,2,0)] [(3,4) (5,6)]
+        [(1,2,0)] [(4,3) (6,5)]
+        [(2,1,0)] [(3,4) (5,6)]
+        [(2,1,0)] [(4,3) (6,5)]
+        [(1,0,2)] [(3,4) (5,6)]
+        [(1,0,2)] [(4,3) (6,5)]
+        [(2,0,1)] [(3,4) (5,6)]
+        [(2,0,1)] [(4,3) (6,5)]
+        [(0,1,2)] [(3,4) (5,6)]
+        [(0,1,2)] [(4,3) (6,5)]
+        [(0,2,1)] [(3,4) (5,6)]
+        [(0,2,1)] [(4,3) (6,5)]
+        
+    :param groups: The symmetry groups list.
+    
+    :return: yields one permutation at a time.
+    """
+    if len(groups) > 0:
+        head = groups[0]
+        for perm in permutations(range(len(head[0]))):
+            swapped_head = []
+            for item in head:
+                swapped_head.append([item[i] for i in perm])
+            for tail_permutation in symm_permutations_new(groups[1:]):
+                yield [swapped_head] + tail_permutation
+    else:
+        yield []
+
         
 def swap_atoms(coordset_reference, atom_i, atom_j):
     #print("PRIMA", coordset_reference)

--- a/pyRMSD/test/testRMSDCalculators.py
+++ b/pyRMSD/test/testRMSDCalculators.py
@@ -252,6 +252,9 @@ class TestRMSDCalculators(unittest.TestCase):
         
         
     def test_fitting_symmetry_new(self):
+        """
+        Runs the RMSD Calculation with fitting symmetry groups with more than 2 elements per symm group
+        """
         protein_skeleton = numpy.array([[0, 0, 0],[0, 1, 0],[0, 0, 1],[1, 0, 0],[1, 1, 1]])
         thetas = [0, numpy.pi / 6, numpy.pi / 2, numpy.pi]
         proteins = []
@@ -259,7 +262,7 @@ class TestRMSDCalculators(unittest.TestCase):
         for i in range(4):
             t = thetas[i]
             rot_matrix = numpy.array([[1, 0, 0], [0, numpy.cos(t), -numpy.sin(t)], [0, numpy.sin(t), numpy.cos(t)]])
-            proteins.append((rot_matrix @ protein_skeleton.T).T + i * 3)
+            proteins.append(numpy.matmul(rot_matrix, protein_skeleton.T).T + i * 3)
         p1, p2, p3, p4 = proteins
         coords = [numpy.concatenate([p1, p2, p3, p4], axis=0),
                   numpy.concatenate([p1, p3, p2, p4], axis=0),

--- a/pyRMSD/test/testRMSDCalculators.py
+++ b/pyRMSD/test/testRMSDCalculators.py
@@ -249,6 +249,32 @@ class TestRMSDCalculators(unittest.TestCase):
                                                                              ])
         rmsds = calculator.oneVsFollowing(0)
         numpy.testing.assert_almost_equal(expected_rmsds, rmsds, 12)
+        
+        
+    def test_fitting_symmetry_new(self):
+        protein_skeleton = numpy.array([[0, 0, 0],[0, 1, 0],[0, 0, 1],[1, 0, 0],[1, 1, 1]])
+        thetas = [0, numpy.pi / 6, numpy.pi / 2, numpy.pi]
+        proteins = []
+        # axis is (1, 0, 0)
+        for i in range(4):
+            t = thetas[i]
+            rot_matrix = numpy.array([[1, 0, 0], [0, numpy.cos(t), -numpy.sin(t)], [0, numpy.sin(t), numpy.cos(t)]])
+            proteins.append((rot_matrix @ protein_skeleton.T).T + i * 3)
+        p1, p2, p3, p4 = proteins
+        coords = [numpy.stack([p1, p2, p3, p4], axis=0),
+                  numpy.stack([p1, p3, p2, p4], axis=0),
+                  numpy.stack([p3, p4, p1, p2], axis=0),
+                  numpy.stack([p2, p1, p4, p3], axis=0),
+                  numpy.stack([p4, p3, p1, p2], axis=0),
+                  numpy.stack([p4, p2, p3, p1], axis=0)]
+        expected_rmsds = [0, 0, 0, 0, 0]
+        calculator = pyRMSD.RMSDCalculator.RMSDCalculator("QTRFIT_SERIAL_CALCULATOR", 
+                                                          fittingCoordsets=numpy.array(coords),
+                                                          fitSymmetryGroups=[
+                                                                                [[0,5,10,15], [1,6,11,16], [2,7,12,17], [3,8,13,18], [4,9,14,19]],
+                                                                             ])
+        rmsds = calculator.oneVsFollowing(0)
+        numpy.testing.assert_allclose(expected_rmsds, rmsds, rtol=1e-7)
     
     def test_calc_symmetry(self):
         

--- a/pyRMSD/test/testRMSDCalculators.py
+++ b/pyRMSD/test/testRMSDCalculators.py
@@ -261,12 +261,12 @@ class TestRMSDCalculators(unittest.TestCase):
             rot_matrix = numpy.array([[1, 0, 0], [0, numpy.cos(t), -numpy.sin(t)], [0, numpy.sin(t), numpy.cos(t)]])
             proteins.append((rot_matrix @ protein_skeleton.T).T + i * 3)
         p1, p2, p3, p4 = proteins
-        coords = [numpy.stack([p1, p2, p3, p4], axis=0),
-                  numpy.stack([p1, p3, p2, p4], axis=0),
-                  numpy.stack([p3, p4, p1, p2], axis=0),
-                  numpy.stack([p2, p1, p4, p3], axis=0),
-                  numpy.stack([p4, p3, p1, p2], axis=0),
-                  numpy.stack([p4, p2, p3, p1], axis=0)]
+        coords = [numpy.concatenate([p1, p2, p3, p4], axis=0),
+                  numpy.concatenate([p1, p3, p2, p4], axis=0),
+                  numpy.concatenate([p3, p4, p1, p2], axis=0),
+                  numpy.concatenate([p2, p1, p4, p3], axis=0),
+                  numpy.concatenate([p4, p3, p1, p2], axis=0),
+                  numpy.concatenate([p4, p2, p3, p1], axis=0)]
         expected_rmsds = [0, 0, 0, 0, 0]
         calculator = pyRMSD.RMSDCalculator.RMSDCalculator("QTRFIT_SERIAL_CALCULATOR", 
                                                           fittingCoordsets=numpy.array(coords),

--- a/pyRMSD/test/testSymmTools.py
+++ b/pyRMSD/test/testSymmTools.py
@@ -89,14 +89,14 @@ class Test(unittest.TestCase):
         for i, perm in enumerate(symm_permutations_new(groups)):
             all_perms.append(perm)
             
-        all_perms = sorted(all_perm)
+        all_perms = sorted(all_perms)
         expected_permutations = sorted(expected_permutations)
         self.assertListEqual(all_perms, expected_permutations)
         
         # test for empty permutation set
         groups = []
         all_perms = [i for i in symm_permutations_new(groups)]
-        self.assertEqual(len(all_perms), 0)
+        self.assertEqual(len(all_perms), 1)
         self.assertEqual(len(all_perms[0]), 0)
             
     def test_swap_atoms(self):

--- a/pyRMSD/test/testSymmTools.py
+++ b/pyRMSD/test/testSymmTools.py
@@ -5,6 +5,7 @@ Created on 29/07/2013
 """
 import unittest
 from pyRMSD.symmTools import  symm_permutations, swap_atoms, min_rmsd_of_rmsds_list, symm_groups_validation
+from pyRMSD.symmTools import symm_groups_validation_new, symm_permutations_new
 import numpy
 
 
@@ -19,7 +20,8 @@ class Test(unittest.TestCase):
                                         # We will try with the following combinations:
                                         # (3,4)  (5,6)
                                         # (4,3)  (6,5)
-
+        
+        symm_group_3 = [ [1,2,3],[4,5,6] ]  # multi-unit symm group, Atoms 1, 2, 3 are equivalent and so are 4, 5, 6
         # The validation function validates a list of this symmetry groups. When we use this list, all permutations are
         # used (i.e. sym_perm(symm_group_1) x sym_perm(symm_group_2)). That is:
         # (1,2) (3,4)  (5,6)
@@ -37,9 +39,13 @@ class Test(unittest.TestCase):
         except ValueError:
             self.fail("Value exception has been raised.")
     
-        symm_group_3 = [ [2,1,3] ] # A symm group must have elements of len 2
-         
+        # Old validation check fails
         self.assertRaises(ValueError, symm_groups_validation, [symm_group_3])
+        # New validation check passes
+        try:
+            symm_groups_validation_new([symm_group_3])
+        except ValueError:
+            self.fail("Value exception has been raised.")
 
     def test_symm_group_permutations(self):
         groups = [
@@ -57,6 +63,35 @@ class Test(unittest.TestCase):
         
         for i, perm in enumerate(symm_permutations(groups)):
             self.assertSequenceEqual(expected_permutations[i], perm)
+            
+    def test_symm_group_permutations_new(self):
+        groups = [
+                  [ [1,2] ],
+                  [ [3,4,5],[6,7,8] ]
+                  ]
+        
+        expected_permutations = [
+                                    [ [[1,2]], [[3,4,5], [6,7,8]]],
+                                    [ [[1,2]], [[3,5,4], [6,8,7]]],
+                                    [ [[1,2]], [[4,3,5], [7,6,8]]],
+                                    [ [[1,2]], [[4,5,3], [7,8,6]]],
+                                    [ [[1,2]], [[5,3,4], [8,6,7]]],
+                                    [ [[1,2]], [[5,4,3], [8,7,6]]],
+                                    [ [[2,1]], [[3,4,5], [6,7,8]]],
+                                    [ [[2,1]], [[3,5,4], [6,8,7]]],
+                                    [ [[2,1]], [[4,3,5], [7,6,8]]],
+                                    [ [[2,1]], [[4,5,3], [7,8,6]]],
+                                    [ [[2,1]], [[5,3,4], [8,6,7]]],
+                                    [ [[2,1]], [[5,4,3], [8,7,6]]],
+                                ]
+        
+        all_perms = []
+        for i, perm in enumerate(symm_permutations_new(groups)):
+            all_perms.append(perm)
+            
+        all_perms = sorted(all_perm)
+        expected_permutations = sorted(expected_permutations)
+        self.assertListEqual(all_perms, expected_permutations)
             
     def test_swap_atoms(self):
         coordsets = numpy.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]])

--- a/pyRMSD/test/testSymmTools.py
+++ b/pyRMSD/test/testSymmTools.py
@@ -42,10 +42,7 @@ class Test(unittest.TestCase):
         # Old validation check fails
         self.assertRaises(ValueError, symm_groups_validation, [symm_group_3])
         # New validation check passes
-        try:
-            symm_groups_validation_new([symm_group_3])
-        except ValueError:
-            self.fail("Value exception has been raised.")
+        symm_groups_validation_new([symm_group_3])
 
     def test_symm_group_permutations(self):
         groups = [
@@ -65,6 +62,9 @@ class Test(unittest.TestCase):
             self.assertSequenceEqual(expected_permutations[i], perm)
             
     def test_symm_group_permutations_new(self):
+        """
+        Tests the generation of permutations for symm-groups containing more than 2 elements per group
+        """
         groups = [
                   [ [1,2] ],
                   [ [3,4,5],[6,7,8] ]
@@ -92,6 +92,12 @@ class Test(unittest.TestCase):
         all_perms = sorted(all_perm)
         expected_permutations = sorted(expected_permutations)
         self.assertListEqual(all_perms, expected_permutations)
+        
+        # test for empty permutation set
+        groups = []
+        all_perms = [i for i in symm_permutations_new(groups)]
+        self.assertEqual(len(all_perms), 0)
+        self.assertEqual(len(all_perms[0]), 0)
             
     def test_swap_atoms(self):
         coordsets = numpy.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]])


### PR DESCRIPTION
Currently, sampcon converts any symmetry group with more than 2 elements into all combinations of 2-element groups selected from it, resulting in a permutation count of `2^(2Cn)`. In order to remove the redundancy (resulting into `n!` permutation count), I am trying to allow `pyRMSD.RMSDCalculator.OneVsFollowing` to directly parse symmetry groups larger than 2 elements. This only works for fit-symmetry groups since the calculation-symmetry groups are implemented in C++. 