### PR TITLE
Remove printing of calculator name

### DIFF
--- a/src/calculators/factory/RMSDCalculatorFactory.cpp
+++ b/src/calculators/factory/RMSDCalculatorFactory.cpp
@@ -85,12 +85,10 @@ RMSDCalculator* RMSDCalculatorFactory::createCalculator(
 			break;
 
 		case NOSUP_SERIAL_CALCULATOR:
-		    cout<<"NOSUP_SERIAL_CALCULATOR"<<endl;
 			kernelFunctions = new NoSuperpositionSerialKernel;
 			break;
 
 		case NOSUP_OMP_CALCULATOR:
-		    cout<<"NOSUP_OMP_CALCULATOR"<<endl;
 			kernelFunctions = new NoSuperpositionOmpKernel(number_of_threads);
 			break;
 


### PR DESCRIPTION
Currently, the printing command is called for every permutation with fit-symmetry-groups or every call of `oneVsFollowing` making the STDOUT excessively cluttered. I don't think the printing serves any purpose in the `Factory`. If the calculator name needs to be printed, it can be in the `RMSDCalculator.__init__` but might not be needed there too.